### PR TITLE
Add test case for LocalDate and BigDecimal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+*target

--- a/src/it/params/src/main/resources/openapi/params.yaml
+++ b/src/it/params/src/main/resources/openapi/params.yaml
@@ -24,6 +24,12 @@ paths:
           type: array
           items:
             type: string
+      - name: c
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date
       tags:
       - query
       responses:
@@ -46,3 +52,5 @@ components:
           type: array
           items:
             type: string
+        d:
+          type: number


### PR DESCRIPTION
Hello,

I am using this tool to generate client code for my swagger definitions and I get errors for data type format `date` and data type `number`: 

`
[ERROR] /path/to/class.java:[123,42] cannot find symbol
  symbol:   class LocalDate
`

`
[ERROR] /path/to/class.java:[123,42] cannot find symbol
  symbol:   class BigDecimal
`

Here is test case for the same.